### PR TITLE
#2172 twitterkitをforkリポジトリへ向ける

### DIFF
--- a/TwitterCore/TwitterCore-Info.plist
+++ b/TwitterCore/TwitterCore-Info.plist
@@ -17,14 +17,14 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0</string>
+	<string>3.2.0.1</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>iPhoneOS</string>
 		<string>iPhoneSimulator</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1026</string>
+	<string>1027</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2015 Twitter Inc.</string>
 </dict>

--- a/TwitterCore/TwitterCore.podspec
+++ b/TwitterCore/TwitterCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "TwitterCore"
-  s.version           = "3.2.0"
+  s.version           = "3.2.0.1"
   s.summary           = "Increase user engagement and app growth."
   s.homepage          = "https://github.com/twitter/twitter-kit-ios"
   s.documentation_url = "https://github.com/twitter/twitter-kit-ios/wiki"
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors           = "Twitter"
   s.platforms         = { :ios => "9.0", :tvos => "9.0" }
   s.source            = { :git => 'https://github.com/d-o-n-u-t-s/mixch-twitter-kit-ios.git',
-                          :branch => "master"
+                          :tag => "v#{s.version}"
                         }
   s.source_files      = [ 'TwitterCore/TwitterCore/**/*.{h,m}',
                           'TwitterCore/TwitterCore-dynamic/TwitterCore.h',

--- a/TwitterCore/TwitterCore.podspec
+++ b/TwitterCore/TwitterCore.podspec
@@ -1,16 +1,32 @@
 Pod::Spec.new do |s|
-  s.name = "TwitterCore"
-  s.version = "3.2.0"
-  s.summary = "Increase user engagement and app growth."
-  s.homepage = "https://github.com/twitter/twitter-kit-ios"
+  s.name              = "TwitterCore"
+  s.version           = "3.2.0"
+  s.summary           = "Increase user engagement and app growth."
+  s.homepage          = "https://github.com/twitter/twitter-kit-ios"
   s.documentation_url = "https://github.com/twitter/twitter-kit-ios/wiki"
-  s.social_media_url = "https://twitter.com/TwitterDev"
-  s.authors = "Twitter"
-  s.platforms = { :ios => "9.0", :tvos => "9.0" }
-  s.source = { :http => "https://ton.twimg.com/syndication/twitterkit/ios/#{s.version}/TwitterCore.zip" }
-  s.license = { :type => "Commercial", :text => "Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md" }
-  s.ios.vendored_frameworks = "iOS/TwitterCore.framework"
-  s.tvos.vendored_frameworks = "tvOS/TwitterCore.framework"
-  s.ios.frameworks = "Accounts", "CoreData", "CoreGraphics", "Foundation", "Security", "Social", "UIKit"
-  s.tvos.frameworks = "CoreData", "CoreGraphics", "Foundation", "Security", "UIKit"
+  s.social_media_url  = "https://twitter.com/TwitterDev"
+  s.authors           = "Twitter"
+  s.platforms         = { :ios => "9.0", :tvos => "9.0" }
+  s.source            = { :git => 'https://github.com/d-o-n-u-t-s/mixch-twitter-kit-ios.git',
+                          :branch => "master"
+                        }
+  s.source_files      = [ 'TwitterCore/TwitterCore/**/*.{h,m}',
+                          'TwitterCore/TwitterCore-dynamic/TwitterCore.h',
+                          'TwitterCore/libextobjc/*.h'
+                        ]
+
+  pch_AF = <<-EOS
+#import <Foundation/Foundation.h>
+#import "TWTRDefines.h"
+#import "EXTKeyPathCoding.h"
+#import "EXTScope.h"
+EOS
+  s.prefix_header_contents = pch_AF
+
+  s.requires_arc      = true
+  s.license           = { :type => "Commercial",
+                          :text => "Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md"
+                        }
+  s.ios.frameworks    = [ "Accounts", "CoreData", "CoreGraphics", "Foundation", "Security", "Social", "UIKit" ]
+  s.tvos.frameworks   = [ "CoreData", "CoreGraphics", "Foundation", "Security", "UIKit" ]
 end

--- a/TwitterKit/TwitterKit-Info.plist
+++ b/TwitterKit/TwitterKit-Info.plist
@@ -17,14 +17,14 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>iPhoneOS</string>
 		<string>iPhoneSimulator</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1032</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2014 Twitter Inc.</string>
 </dict>

--- a/TwitterKit/TwitterKit.podspec
+++ b/TwitterKit/TwitterKit.podspec
@@ -1,16 +1,47 @@
 Pod::Spec.new do |s|
-  s.name = "TwitterKit"
-  s.version = "3.4.2"
-  s.summary = "Increase user engagement and app growth."
-  s.homepage = "https://github.com/twitter/twitter-kit-ios"
+  s.name              = "TwitterKit"
+  s.version           = "3.4.2"
+  s.summary           = "Increase user engagement and app growth."
+  s.homepage          = "https://github.com/twitter/twitter-kit-ios"
   s.documentation_url = "https://github.com/twitter/twitter-kit-ios/wiki"
-  s.social_media_url = "https://twitter.com/TwitterDev"
-  s.authors = "Twitter"
-  s.platform = :ios, "9.0"
-  s.source = { :http => "https://ton.twimg.com/syndication/twitterkit/ios/#{s.version}/TwitterKit.zip" }
-  s.vendored_frameworks = "iOS/TwitterKit.framework"
-  s.license = { :type => "Commercial", :text => "Twitter Kit: Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md"}
-  s.resources = ["iOS/TwitterKit.framework/TwitterKitResources.bundle", "iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle"]
-  s.frameworks = "CoreText", "QuartzCore", "CoreData", "CoreGraphics", "Foundation", "Security", "UIKit", "CoreMedia", "AVFoundation", "SafariServices"
-  s.dependency "TwitterCore", ">= 3.1.0"
+  s.social_media_url  = "https://twitter.com/TwitterDev"
+  s.authors           = "Twitter"
+  s.platform          = :ios, "9.0"
+  s.source            = { :git => 'https://github.com/d-o-n-u-t-s/mixch-twitter-kit-ios.git',
+                          :branch => 'feature/2172-change-twitterkit-to-fork-repository'
+                          #:tag => "v#{s.version}"
+                        }
+
+  s.source_files      = [ 'TwitterKit/TwitterKit/{Networking,Persistence,Resources,Social,Supporting Files,TwitterShareExtensionUI}/**/*.{h,m}',
+                          'TwitterKit/TwitterKit/External/Punycode Cocoa/Pod/*.{h,m}',
+                          'TwitterKit/TwitterKit/*.{h,m}',
+                          'TwitterKit/libextobjc/*.h'
+                        ]
+  s.exclude_files     = 'TwitterKit/TwitterKit/**/{TWTRTimelineViewController}.{h,m}'
+
+pch_AF = <<-EOS
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <TwitterCore/TWTRDefines.h>
+#define IS_UIKIT_AVAILABLE (TARGET_OS_IOS || TARGET_OS_TV)
+
+#ifndef NS_DESIGNATED_INITIALIZER
+    #if __has_attribute(objc_designated_initializer)
+        #define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+    #else
+        #define NS_DESIGNATED_INITIALIZER
+    #endif
+#endif
+
+#import "EXTKeyPathCoding.h"
+#import "EXTScope.h"
+EOS
+  s.prefix_header_contents = pch_AF
+
+  s.requires_arc      = true
+  s.license           = { :type => "Commercial",
+                          :text => "Twitter Kit: Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md"
+                        }
+  s.resources         = [ "TwitterKit/TwitterKitResources.bundle" ]
+  s.frameworks        = "CoreText", "QuartzCore", "CoreData", "CoreGraphics", "Foundation", "Security", "UIKit", "CoreMedia", "AVFoundation", "SafariServices"
 end

--- a/TwitterKit/TwitterKit.podspec
+++ b/TwitterKit/TwitterKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "TwitterKit"
-  s.version           = "3.4.2"
+  s.version           = "3.4.2.1"
   s.summary           = "Increase user engagement and app growth."
   s.homepage          = "https://github.com/twitter/twitter-kit-ios"
   s.documentation_url = "https://github.com/twitter/twitter-kit-ios/wiki"
@@ -8,8 +8,7 @@ Pod::Spec.new do |s|
   s.authors           = "Twitter"
   s.platform          = :ios, "9.0"
   s.source            = { :git => 'https://github.com/d-o-n-u-t-s/mixch-twitter-kit-ios.git',
-                          :branch => 'feature/2172-change-twitterkit-to-fork-repository'
-                          #:tag => "v#{s.version}"
+                          :tag => "v#{s.version}"
                         }
 
   s.source_files      = [ 'TwitterKit/TwitterKit/{Networking,Persistence,Resources,Social,Supporting Files,TwitterShareExtensionUI}/**/*.{h,m}',

--- a/TwitterKit/TwitterKit.xcodeproj/project.pbxproj
+++ b/TwitterKit/TwitterKit.xcodeproj/project.pbxproj
@@ -3569,7 +3569,9 @@
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1033;
 				ENABLE_BITCODE = YES;
+				MARKETING_VERSION = 3.4.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -3586,7 +3588,9 @@
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1033;
 				ENABLE_BITCODE = YES;
+				MARKETING_VERSION = 3.4.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/TwitterKit/TwitterKit/TWTRKit.h
+++ b/TwitterKit/TwitterKit/TWTRKit.h
@@ -34,7 +34,7 @@
 #import "TWTRListTimelineDataSource.h"
 #import "TWTRLogInButton.h"
 #import "TWTRMediaEntitySize.h"
-#ifndef CREATE_WITH_COCOAPODS
+#ifndef COCOAPODS
 #import "TWTRMoPubAdConfiguration.h"
 #import "TWTRMoPubNativeAdContainerView.h"
 #endif
@@ -46,7 +46,7 @@
 #import "TWTRTimelineDelegate.h"
 #import "TWTRTimelineFilter.h"
 #import "TWTRTimelineType.h"
-#ifndef CREATE_WITH_COCOAPODS
+#ifndef COCOAPODS
 #import "TWTRTimelineViewController.h"
 #endif
 #import "TWTRTweet.h"

--- a/TwitterKit/TwitterKit/TWTRKit.h
+++ b/TwitterKit/TwitterKit/TWTRKit.h
@@ -34,8 +34,10 @@
 #import "TWTRListTimelineDataSource.h"
 #import "TWTRLogInButton.h"
 #import "TWTRMediaEntitySize.h"
+#ifndef CREATE_WITH_COCOAPODS
 #import "TWTRMoPubAdConfiguration.h"
 #import "TWTRMoPubNativeAdContainerView.h"
+#endif
 #import "TWTRNotificationConstants.h"
 #import "TWTROAuthSigning.h"
 #import "TWTRSearchTimelineDataSource.h"
@@ -44,7 +46,9 @@
 #import "TWTRTimelineDelegate.h"
 #import "TWTRTimelineFilter.h"
 #import "TWTRTimelineType.h"
+#ifndef CREATE_WITH_COCOAPODS
 #import "TWTRTimelineViewController.h"
+#endif
 #import "TWTRTweet.h"
 #import "TWTRTweetCashtagEntity.h"
 #import "TWTRTweetEntity.h"

--- a/TwitterKit/TwitterKit/TWTRTwitter.m
+++ b/TwitterKit/TwitterKit/TWTRTwitter.m
@@ -356,6 +356,7 @@ static TWTRTwitter *sharedTwitter;
     [self.webAuthenticationFlow beginAuthenticationFlow:^(UIViewController *controller) {
         __strong typeof(weakViewController) strongViewController = weakViewController;
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:controller];
+        navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
         [strongViewController presentViewController:navigationController animated:YES completion:nil];
     }
         completion:^(TWTRSession *session, NSError *error) {


### PR DESCRIPTION
## 概要
d-o-n-u-t-s/mixch-doc#2172

## 動作確認方法
- 動作確認するために分かりにくい手順などあればここに書いておく

## やったこと
- [] ソースで取り込めるようにpodspecを変更
- [] iOS11と12でフォアグラウンド直後にネットワーク通信すると失敗する不具合があるため遅延実行
- [] web認証をセミモーダルからフルスクリーン表示に変更

|before|after|
|------|-----|
|||

## テスト
- [こちら](https://github.com/d-o-n-u-t-s/mixch-ios/pull/1282)でテスト

### テスト観点
- テキスト関連
   - 絵文字を入力
   - 文字数が多い場合
- ネットワーク関連
   - オフライン状態
   - 通信状態が悪い
- UI
   - ノッチあり・なし
   - ディスプレイサイズの違い
   - jやqなどでdesentが文字切れしていないか
   - タブバーに埋もれていないか
   - 画面回転
- OS
   - OSの違い
