### PR TITLE
#2375 twitterkit内のUIWebViewをWKWebViewにする

### DIFF
--- a/TwitterCore/TwitterCore.podspec
+++ b/TwitterCore/TwitterCore.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors           = "Twitter"
   s.platforms         = { :ios => "9.0", :tvos => "9.0" }
   s.source            = { :git => 'https://github.com/d-o-n-u-t-s/mixch-twitter-kit-ios.git',
-                          :branch => "master"
+                          :branch => "feature/2375-twitterkit-wkwebview"
                         }
   s.source_files      = [ 'TwitterCore/TwitterCore/**/*.{h,m}',
                           'TwitterCore/TwitterCore-dynamic/TwitterCore.h',

--- a/TwitterKit/TwitterKit.podspec
+++ b/TwitterKit/TwitterKit.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors           = "Twitter"
   s.platform          = :ios, "9.0"
   s.source            = { :git => 'https://github.com/d-o-n-u-t-s/mixch-twitter-kit-ios.git',
-                          :branch => 'feature/2172-change-twitterkit-to-fork-repository'
+                          :branch => 'feature/2375-twitterkit-wkwebview'
                           #:tag => "v#{s.version}"
                         }
 

--- a/TwitterKit/TwitterKit/Social/Identity/TWTRWebViewController.h
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRWebViewController.h
@@ -20,10 +20,11 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 
 @class TWTRWebViewController;
 
-typedef BOOL (^TWTRWebViewControllerShouldLoadCompletion)(UIViewController *controller, NSURLRequest *request, UIWebViewNavigationType navigationType);
+typedef BOOL (^TWTRWebViewControllerShouldLoadCompletion)(UIViewController *controller, NSURLRequest *request, WKNavigationType navigationType);
 typedef void (^TWTRWebViewControllerCancelCompletion)(TWTRWebViewController *webViewController);
 typedef void (^TWTRWebViewControllerHandleError)(NSError *error);
 

--- a/TwitterKit/TwitterKit/Social/Identity/TWTRWebViewController.m
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRWebViewController.m
@@ -18,9 +18,9 @@
 #import "TWTRWebViewController.h"
 #import <TwitterCore/TWTRAuthenticationConstants.h>
 
-@interface TWTRWebViewController () <UIWebViewDelegate>
+@interface TWTRWebViewController () <WKNavigationDelegate>
 
-@property (nonatomic, strong) UIWebView *webView;
+@property (nonatomic, strong) WKWebView *webView;
 @property (nonatomic, assign) BOOL showCancelButton;
 @property (nonatomic, copy) TWTRWebViewControllerCancelCompletion cancelCompletion;
 
@@ -65,29 +65,35 @@
 
 - (void)loadView
 {
-    [self setWebView:[[UIWebView alloc] init]];
-    [[self webView] setScalesPageToFit:YES];
-    [[self webView] setDelegate:self];
+    [self setWebView:[[WKWebView alloc] init]];
+    [[self webView] setNavigationDelegate:self];
     [self setView:[self webView]];
 }
 
-#pragma mark - UIWebview delegate
+#pragma mark - WKWebView WKNavigation delegate
 
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
+    NSURLRequest *request = navigationAction.request;
+    
     if (![self whitelistedDomain:request]) {
         // Open in Safari if request is not whitelisted
         NSLog(@"Opening link in Safari browser, as the host is not whitelisted: %@", request.URL);
         [[UIApplication sharedApplication] openURL:request.URL];
-        return NO;
+        decisionHandler(WKNavigationActionPolicyCancel);
+        return;
     }
     if ([self shouldStartLoadWithRequest]) {
-        return [self shouldStartLoadWithRequest](self, request, navigationType);
+        if (![self shouldStartLoadWithRequest](self, request, navigationAction.navigationType)) {
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
+        }
     }
-    return YES;
+    
+    decisionHandler(WKNavigationActionPolicyAllow);
 }
 
-- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error
 {
     if (self.errorHandler) {
         self.errorHandler(error);

--- a/TwitterKit/TwitterKit/Social/Syndication/API/TWTRWebAuthenticationFlow.h
+++ b/TwitterKit/TwitterKit/Social/Syndication/API/TWTRWebAuthenticationFlow.h
@@ -38,7 +38,7 @@ typedef void (^TWTRAuthRedirectCompletion)(NSURL *url);
 
 /**
  * Presents a simple interface for performing 3 legged OAuth with Twitter. This
- * will choose automatically whether to use UIWebView or SFSafariViewController
+ * will choose automatically whether to use WKWebView or SFSafariViewController
  * based on class availability and the presence of a valid TwitterKit URL scheme.
  */
 @interface TWTRWebAuthenticationFlow : NSObject

--- a/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRWebAuthenticationViewController.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRWebAuthenticationViewController.m
@@ -102,7 +102,7 @@
         @strongify(self)[self failWithError:error];
     };
 
-    webVC.shouldStartLoadWithRequest = ^BOOL(UIViewController *controller, NSURLRequest *request, UIWebViewNavigationType navType) {
+    webVC.shouldStartLoadWithRequest = ^BOOL(UIViewController *controller, NSURLRequest *request, WKNavigationType navType) {
         @strongify(self) NSURL *URL = request.URL;
         if ([TWTRSDKScheme isEqualToString:URL.scheme] && [TWTRSDKRedirectHost isEqualToString:URL.host]) {
             [self handleTwitterRedirectRequest:request];

--- a/TwitterKit/TwitterKit/Social/Syndication/Models/TWTRTweet.h
+++ b/TwitterKit/TwitterKit/Social/Syndication/Models/TWTRTweet.h
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The permalink URL for this Tweet.
  *
- *  Suitable for loading in a `UIWebView`, `WKWebView` or passing to Safari:
+ *  Suitable for loading in a `WKWebView` or passing to Safari:
  *
  *  `[[UIApplication sharedApplication] openURL:tweet.permalink];`
  */

--- a/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRLikeButton.h
+++ b/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRLikeButton.h
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSInteger, TWTRLikeButtonSize) {
 @interface TWTRLikeButton : UIButton
 
 /**
- *  The view controller from which to present the login UIWebView or
+ *  The view controller from which to present the login WKWebView or
  *  account picker sheet.
  */
 @property (nonatomic, weak, null_resettable) UIViewController *presenterViewController;

--- a/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetMediaView.h
+++ b/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetMediaView.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) TWTRTweetViewStyle style;
 
 /**
- *  The view controller from which to present the login UIWebView or
+ *  The view controller from which to present the login WKWebView or
  *  account picker sheet.
  */
 @property (nonatomic, weak, null_resettable) UIViewController *presenterViewController;


### PR DESCRIPTION
## 概要
d-o-n-u-t-s/mixch-doc#2375

## 動作確認方法

## やったこと
- [] UIWebViewが利用されているところをWKWebViewに変更

|before|after|
|------|-----|
|||

## 動作確認端末
- [ ] 【SYS1015】iPhone11 Pro Max 13.3 (2ファクタ可能)
- [ ] 【SYS1006】iPhone11 13.1.2
- [ ] 【SYS1000】iPhone8 12.4
- [ ] 【SYS961】iPhoneXR 12.4
- [ ] 【SYS886】iPhoneXs Max 12.1.2
- [ ] 【SYS834】iPhoneX 13.0
- [x] 【SYS828】iPhoneX 11.2.6
- [ ] 【SYS670】iPhone7 Plus 11.2.1 (2ファクタ可能)
- [x] 【SYS653】iPhone7 13.2.3 (2ファクタ可能)
- [ ] 【SYS451】iPhone5s 11.4.1
- [ ] 【SYS427】iPhone6 12.0
- [ ] 【SYS410】iPhone5s 11.4.1
- [ ] 【SYS377】iPhone6s Plus 13.2.3
- [x] 【SYS160】iPhoneSE 13.3 (2ファクタ可能)
- [ ] 【SYS153】iPhone6 Plus 12.4.3

## テスト
- twitterアプリをインストール状態
  - [x] twitterログインできること
- twitterアプリをアンインストール状態
  - [x] twitterログインできること
  - [x] アカウント管理でTwitter連携を追加できること
  - [x] 動画投稿時のSNSに共有でTwitterで共有できること
  - [x] 動画投稿時のTwitter共有できること
  - [x] ライブ配信開始時のTwitter共有できること
  - [x] ライブ視聴中のTwitter共有できること
  - [x] ライブ配信終了時のTwitter共有できること
  - [x] ライブ配信予告のTwitter共有できること

### テスト観点
- テキスト関連
   - 絵文字を入力
   - 文字数が多い場合
- ネットワーク関連
   - オフライン状態
   - 通信状態が悪い
- UI
   - ノッチあり・なし
   - ディスプレイサイズの違い
   - jやqなどでdesentが文字切れしていないか
   - タブバーに埋もれていないか
   - 画面回転
- OS
   - OSの違い
